### PR TITLE
Authorization middleware

### DIFF
--- a/src/Exception/UnauthorizedException.php
+++ b/src/Exception/UnauthorizedException.php
@@ -18,6 +18,8 @@
 
 namespace ZfrLightspeedRetail\Exception;
 
+use Exception;
+
 /**
  * @author Daniel Gimenes
  */
@@ -31,8 +33,46 @@ class UnauthorizedException extends RuntimeException
     public static function authorizationCodeRejected(string $authorizationCode): self
     {
         return new self(sprintf(
-            'Authorization code "%s" was rejected by Lightspeed Authorization Server',
+            'Authorization code "%s" was rejected by Lightspeed Authorization Server.',
             $authorizationCode
         ));
+    }
+
+    /**
+     * @return UnauthorizedException
+     */
+    public static function missingReferenceId(): self
+    {
+        return new self(
+            'Missing "referenceID" command param.'
+            . ' This is required to fetch the credentials from credential storage'
+        );
+    }
+
+    /**
+     * @param string $referenceID
+     *
+     * @return UnauthorizedException
+     */
+    public static function missingCredential(string $referenceID): self
+    {
+        return new self(sprintf(
+            'No credential found in credential storage for "%s".',
+            $referenceID
+        ));
+    }
+
+    /**
+     * @param string         $refreshToken
+     * @param Exception|null $exception
+     *
+     * @return UnauthorizedException
+     */
+    public static function refreshTokenRejected(string $refreshToken, Exception $exception = null): self
+    {
+        return new self(sprintf(
+            'The refresh token "%s" was rejected by Lightspeed Authorization Server',
+            $refreshToken
+        ), 0, $exception);
     }
 }

--- a/src/OAuth/AuthorizationMiddleware.php
+++ b/src/OAuth/AuthorizationMiddleware.php
@@ -1,0 +1,191 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrLightspeedRetail\OAuth;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Exception\CommandException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\RejectedPromise;
+use ZfrLightspeedRetail\Exception\UnauthorizedException;
+use ZfrLightspeedRetail\OAuth\CredentialStorage\CredentialStorageInterface;
+use function GuzzleHttp\json_decode as guzzle_json_decode;
+
+/**
+ * @author Daniel Gimenes
+ */
+final class AuthorizationMiddleware
+{
+    private const LS_ENDPOINT_ACCESS_TOKEN = 'https://cloud.merchantos.com/oauth/access_token.php';
+
+    /**
+     * @var callable
+     */
+    private $nextHandler;
+
+    /**
+     * @var CredentialStorageInterface
+     */
+    private $credentialStorage;
+
+    /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+
+    /**
+     * @var string
+     */
+    private $clientId;
+
+    /**
+     * @var string
+     */
+    private $clientSecret;
+
+    /**
+     * @param callable                   $nextHandler
+     * @param CredentialStorageInterface $credentialStorage
+     * @param ClientInterface            $httpClient
+     * @param string                     $clientId
+     * @param string                     $clientSecret
+     */
+    public function __construct(
+        callable $nextHandler,
+        CredentialStorageInterface $credentialStorage,
+        ClientInterface $httpClient,
+        string $clientId,
+        string $clientSecret
+    ) {
+        $this->nextHandler       = $nextHandler;
+        $this->credentialStorage = $credentialStorage;
+        $this->httpClient        = $httpClient;
+        $this->clientId          = $clientId;
+        $this->clientSecret      = $clientSecret;
+    }
+
+    /**
+     * Creates a callable that wraps the middleware with the next handler of @see HandlerStack
+     *
+     * @param CredentialStorageInterface $credentialStorage
+     * @param ClientInterface            $httpClient
+     * @param string                     $clientId
+     * @param string                     $clientSecret
+     *
+     * @return callable
+     */
+    public static function wrapped(
+        CredentialStorageInterface $credentialStorage,
+        ClientInterface $httpClient,
+        string $clientId,
+        string $clientSecret
+    ): callable {
+        return function (callable $nextHandler) use ($credentialStorage, $httpClient, $clientId, $clientSecret) {
+            return new self($nextHandler, $credentialStorage, $httpClient, $clientId, $clientSecret);
+        };
+    }
+
+    /**
+     * @param CommandInterface $command
+     *
+     * @return PromiseInterface
+     */
+    public function __invoke(CommandInterface $command): PromiseInterface
+    {
+        if (empty($command['referenceID'])) {
+            return new RejectedPromise(UnauthorizedException::missingReferenceId());
+        }
+
+        $referenceID = $command['referenceID'];
+        $credential  = $this->credentialStorage->get($referenceID);
+
+        if (null === $credential) {
+            return new RejectedPromise(UnauthorizedException::missingCredential($referenceID));
+        }
+
+        $command = $this->authorizeCommand($command, $credential);
+
+        /** @var PromiseInterface $promise */
+        $promise = ($this->nextHandler)($command);
+
+        // If authentication fails, we refresh the token and try again
+        return $promise->otherwise(function (CommandException $exception) use ($command, $credential) {
+            $response = $exception->getResponse();
+
+            // Forward non 401 errors
+            if (null === $response || 401 !== $response->getStatusCode()) {
+                throw $exception;
+            }
+
+            $credential = $this->refreshToken($credential);
+            $command    = $this->authorizeCommand($command, $credential);
+
+            // Try again
+            return ($this->nextHandler)($command);
+        });
+    }
+
+    /**
+     * @param CommandInterface $command
+     *
+     * @param Credential       $credential
+     *
+     * @return CommandInterface
+     */
+    private function authorizeCommand(CommandInterface $command, Credential $credential): CommandInterface
+    {
+        $command['accountID'] = $credential->getLightspeedAccountId();
+        $command['@http']     = [
+            'headers' => ['Authorization' => 'Bearer ' . $credential->getAccessToken()],
+        ];
+
+        return $command;
+    }
+
+    /**
+     * @param Credential $credential
+     *
+     * @return Credential
+     */
+    private function refreshToken(Credential $credential): Credential
+    {
+        $refreshToken = $credential->getRefreshToken();
+
+        try {
+            $response = $this->httpClient->request('POST', self::LS_ENDPOINT_ACCESS_TOKEN, [
+                'json' => [
+                    'client_id'     => $this->clientId,
+                    'client_secret' => $this->clientSecret,
+                    'refresh_token' => $refreshToken,
+                    'grant_type'    => 'refresh_token',
+                ],
+            ]);
+        } catch (ClientException $exception) {
+            throw UnauthorizedException::refreshTokenRejected($refreshToken, $exception);
+        }
+
+        $result     = guzzle_json_decode((string) $response->getBody(), true);
+        $credential = $credential->withRefreshedTokens($result['access_token'], $result['refresh_token']);
+
+        $this->credentialStorage->save($credential);
+
+        return $credential;
+    }
+}

--- a/src/OAuth/AuthorizationMiddleware.php
+++ b/src/OAuth/AuthorizationMiddleware.php
@@ -181,7 +181,7 @@ final class AuthorizationMiddleware
         }
 
         $result     = guzzle_json_decode((string) $response->getBody(), true);
-        $credential = $credential->withRefreshedTokens($result['access_token'], $result['refresh_token']);
+        $credential = $credential->withTokens($result['access_token'], $result['refresh_token']);
 
         $this->credentialStorage->save($credential);
 

--- a/src/OAuth/AuthorizationMiddleware.php
+++ b/src/OAuth/AuthorizationMiddleware.php
@@ -144,7 +144,6 @@ final class AuthorizationMiddleware
 
     /**
      * @param CommandInterface $command
-     *
      * @param Credential       $credential
      *
      * @return CommandInterface

--- a/src/OAuth/Credential.php
+++ b/src/OAuth/Credential.php
@@ -92,4 +92,20 @@ final class Credential
     {
         return $this->refreshToken;
     }
+
+    /**
+     * @param string $accessToken
+     * @param string $refreshToken
+     *
+     * @return Credential
+     */
+    public function withRefreshedTokens(string $accessToken, string $refreshToken): self
+    {
+        $clone = clone $this;
+
+        $clone->accessToken  = $accessToken;
+        $clone->refreshToken = $refreshToken;
+
+        return $clone;
+    }
 }

--- a/src/OAuth/Credential.php
+++ b/src/OAuth/Credential.php
@@ -99,7 +99,7 @@ final class Credential
      *
      * @return Credential
      */
-    public function withRefreshedTokens(string $accessToken, string $refreshToken): self
+    public function withTokens(string $accessToken, string $refreshToken): self
     {
         $clone = clone $this;
 

--- a/src/OAuth/CredentialStorage/InMemoryCredentialStorage.php
+++ b/src/OAuth/CredentialStorage/InMemoryCredentialStorage.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrLightspeedRetail\OAuth\CredentialStorage;
+
+use ZfrLightspeedRetail\OAuth\Credential;
+
+/**
+ * @author Daniel Gimenes
+ */
+final class InMemoryCredentialStorage implements CredentialStorageInterface
+{
+    /**
+     * @var array
+     */
+    private $credentials;
+
+    /**
+     * @param array $credentials Array of credentials indexed by reference ID
+     */
+    public function __construct(array $credentials)
+    {
+        $this->credentials = $credentials;
+    }
+
+    /**
+     * @param Credential $credential
+     */
+    public function save(Credential $credential)
+    {
+        $this->credentials[$credential->getReferenceId()] = $credential;
+    }
+
+    /**
+     * @param string $referenceId
+     *
+     * @return null|Credential
+     */
+    public function get(string $referenceId): ?Credential
+    {
+        return $this->credentials[$referenceId] ?? null;
+    }
+}

--- a/test/OAuth/AuthorizationMiddlewareTest.php
+++ b/test/OAuth/AuthorizationMiddlewareTest.php
@@ -1,0 +1,269 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrLightspeedRetailTest\OAuth;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Command\Command;
+use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Exception\CommandClientException;
+use GuzzleHttp\Command\Result;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use ZfrLightspeedRetail\Exception\UnauthorizedException;
+use ZfrLightspeedRetail\OAuth\AuthorizationMiddleware;
+use ZfrLightspeedRetail\OAuth\Credential;
+use ZfrLightspeedRetail\OAuth\CredentialStorage\InMemoryCredentialStorage;
+use function GuzzleHttp\json_encode as guzzle_json_encode;
+use function GuzzleHttp\Psr7\stream_for;
+
+/**
+ * @author Daniel Gimenes
+ */
+final class AuthorizationMiddlewareTest extends TestCase
+{
+    public function testAuthorizesCommand()
+    {
+        $referenceId = 'omc-demo.myshopify.com';
+
+        // Initialize storage with valid access token
+        $credentialStorage = new InMemoryCredentialStorage([
+            $referenceId => new Credential($referenceId, 123456, 'valid', 'foo')
+        ]);
+
+        $httpClient = $this->prophesize(ClientInterface::class);
+
+        $middleware = new AuthorizationMiddleware(
+            $this->createNextHandler(),
+            $credentialStorage,
+            $httpClient->reveal(),
+            '123456',
+            'foobar'
+        );
+
+        $httpClient->request(Argument::any())->shouldNotBeCalled();
+
+        $result = $middleware(new Command('Test', ['referenceID' => $referenceId]))->wait();
+
+        $this->assertSame('success', $result['message']);
+    }
+
+    public function testForwardsNon401Errors()
+    {
+        $referenceId = 'omc-demo.myshopify.com';
+
+        // Initialize storage with valid access token
+        $credentialStorage = new InMemoryCredentialStorage([
+            $referenceId => new Credential($referenceId, 123456, 'valid', 'foo')
+        ]);
+
+        $httpClient = $this->prophesize(ClientInterface::class);
+        $middleware = new AuthorizationMiddleware(
+            $this->createNextHandler(),
+            $credentialStorage,
+            $httpClient->reveal(),
+            '123456',
+            'foobar'
+        );
+
+        $httpClient->request(Argument::any())->shouldNotBeCalled();
+
+        $this->expectException(CommandClientException::class);
+        $this->expectExceptionMessage('Huh?');
+
+        // NonExisting command throws 404
+        $middleware(new Command('NonExisting', ['referenceID' => $referenceId]))->wait();
+    }
+
+    public function testRefreshesToken()
+    {
+        $clientId     = '123456';
+        $clientSecret = 'foobar';
+        $referenceId  = 'omc-demo.myshopify.com';
+
+        // Initialize storage with an invalid access token
+        $credentialStorage = new InMemoryCredentialStorage([
+            $referenceId => new Credential($referenceId, 123456, 'invalid', 'foo')
+        ]);
+
+        $httpClient = $this->prophesize(ClientInterface::class);
+        $middleware = new AuthorizationMiddleware(
+            $this->createNextHandler(),
+            $credentialStorage,
+            $httpClient->reveal(),
+            $clientId,
+            $clientSecret
+        );
+
+        // Since Next handler returns CommandClientException, it refreshes the token
+        $httpClient->request('POST', 'https://cloud.merchantos.com/oauth/access_token.php', [
+            'json' => [
+                'client_id'     => $clientId,
+                'client_secret' => $clientSecret,
+                'refresh_token' => 'foo',
+                'grant_type'    => 'refresh_token',
+            ],
+        ])->shouldBeCalled()->willReturn(
+            new Response(200, [], stream_for(guzzle_json_encode([
+                'access_token'  => 'valid',
+                'refresh_token' => 'bar',
+            ])))
+        );
+
+        // Then it calls the next handler with refreshed access token, which returns a valid result
+        $result = $middleware(new Command('Test', ['referenceID' => $referenceId]))->wait();
+
+        $this->assertSame('success', $result['message']);
+
+        // Credential storage should have been updated with the refreshed credentials
+        $refreshedCredential = $credentialStorage->get($referenceId);
+
+        $this->assertSame('valid', $refreshedCredential->getAccessToken());
+        $this->assertSame('bar', $refreshedCredential->getRefreshToken());
+    }
+
+    public function testThrowsExceptionIfRejectedRefreshToken()
+    {
+        $clientId     = '123456';
+        $clientSecret = 'foobar';
+        $referenceId  = 'omc-demo.myshopify.com';
+
+        // Initialize storage with an invalid access token
+        $credentialStorage = new InMemoryCredentialStorage([
+            $referenceId => new Credential($referenceId, 123456, 'invalid', 'foo')
+        ]);
+
+        $httpClient = $this->prophesize(ClientInterface::class);
+        $middleware = new AuthorizationMiddleware(
+            $this->createNextHandler(),
+            $credentialStorage,
+            $httpClient->reveal(),
+            $clientId,
+            $clientSecret
+        );
+
+        // Since Next handler returns CommandClientException, it refreshes the token
+        $httpClient->request('POST', 'https://cloud.merchantos.com/oauth/access_token.php', [
+            'json' => [
+                'client_id'     => $clientId,
+                'client_secret' => $clientSecret,
+                'refresh_token' => 'foo',
+                'grant_type'    => 'refresh_token',
+            ],
+        // But the authorization server rejects the refresh token
+        ])->shouldBeCalled()->willThrow(new ClientException(
+            'Boom!',
+            new Request('POST', 'https://cloud.merchantos.com/oauth/access_token.php'),
+            new Response(400, [], stream_for(guzzle_json_encode([
+                'error'             => 'invalid_grant',
+                'error_description' => 'Invalid refresh token',
+            ])))
+        ));
+
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage('The refresh token "foo" was rejected by Lightspeed Authorization Server');
+
+        $middleware(new Command('Test', ['referenceID' => $referenceId]))->wait();
+    }
+
+    public function testRejectsCommandsWithoutReferenceId()
+    {
+        $httpClient = $this->prophesize(ClientInterface::class);
+        $middleware = new AuthorizationMiddleware(
+            function () {
+                $this->fail('Next handler should not be called');
+            },
+            new InMemoryCredentialStorage([]),
+            $httpClient->reveal(),
+            '123456',
+            'foobar'
+        );
+
+        $httpClient->request(Argument::any())->shouldNotBeCalled();
+
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage(
+            'Missing "referenceID" command param. This is required to fetch the credentials from credential storage'
+        );
+
+        $middleware(new Command('Test'))->wait();
+    }
+
+    public function testRejectsUnauthorizedAccounts()
+    {
+        $httpClient = $this->prophesize(ClientInterface::class);
+        $middleware = new AuthorizationMiddleware(
+            function () {
+                $this->fail('Next handler should not be called');
+            },
+            new InMemoryCredentialStorage([]),
+            $httpClient->reveal(),
+            '123456',
+            'foobar'
+        );
+
+        $httpClient->request(Argument::any())->shouldNotBeCalled();
+
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage(
+            'No credential found in credential storage for "omc-demo.myshopify.com".'
+        );
+
+        $middleware(new Command('Test', ['referenceID' => 'omc-demo.myshopify.com']))->wait();
+    }
+
+    /**
+     * Creates a handler that mimics the Lightspeed API Server
+     *
+     * @return callable
+     */
+    private function createNextHandler(): callable
+    {
+        return function (CommandInterface $command) {
+            // Returns 401 if unauthorized command
+            if (123456 !== $command['accountID'] || 'Bearer valid' !== $command['@http']['headers']['Authorization']) {
+                return new RejectedPromise(new CommandClientException(
+                    'Boom!',
+                    $command,
+                    null,
+                    null,
+                    new Response(401)
+                ));
+            }
+
+            // Returns 404 if command named "NonExisting"
+            if ('NonExisting' === $command->getName()) {
+                return new RejectedPromise(new CommandClientException(
+                    'Huh?',
+                    $command,
+                    null,
+                    null,
+                    new Response(404)
+                ));
+            }
+
+            // Otherwise, returns a valid result
+            return new FulfilledPromise(new Result(['message' => 'success']));
+        };
+    }
+}


### PR DESCRIPTION
Here is the authorization middleware, once we pipe this middleware in `ServiceClient` pipeline, it:
* Fetches the `referenceID` param from command, and use it to fetch the credential from `CredentialStorage`
* Authorizes the command (adds LS accountID and authorization header)
* Runs the command (calls next handler)
* If the API server returns 401, it refreshes the token and tries once again.