### PR TITLE
Fix type of "load_relations" param

### DIFF
--- a/src/ServiceDescription/Lightspeed-Retail-2016.25.php
+++ b/src/ServiceDescription/Lightspeed-Retail-2016.25.php
@@ -62,7 +62,6 @@ return [
                     'location' => 'query',
                     'type'     => 'string',
                     'required' => false,
-                    'filters'  => ['json_encode'],
                 ],
                 'orderby' => [
                     'location' => 'query',
@@ -192,7 +191,6 @@ return [
                     'location' => 'query',
                     'type'     => 'string',
                     'required' => false,
-                    'filters'  => ['json_encode'],
                 ],
                 'orderby' => [
                     'location' => 'query',
@@ -307,7 +305,6 @@ return [
                     'location' => 'query',
                     'type'     => 'string',
                     'required' => false,
-                    'filters'  => ['json_encode'],
                 ],
                 'orderby' => [
                     'location' => 'query',

--- a/src/ServiceDescription/Lightspeed-Retail-2016.25.php
+++ b/src/ServiceDescription/Lightspeed-Retail-2016.25.php
@@ -60,7 +60,7 @@ return [
                 ],
                 'load_relations' => [
                     'location' => 'query',
-                    'type'     => 'array',
+                    'type'     => 'string',
                     'required' => false,
                     'filters'  => ['json_encode'],
                 ],
@@ -190,7 +190,7 @@ return [
                 ],
                 'load_relations' => [
                     'location' => 'query',
-                    'type'     => 'array',
+                    'type'     => 'string',
                     'required' => false,
                     'filters'  => ['json_encode'],
                 ],
@@ -305,7 +305,7 @@ return [
                 ],
                 'load_relations' => [
                     'location' => 'query',
-                    'type'     => 'array',
+                    'type'     => 'string',
                     'required' => false,
                     'filters'  => ['json_encode'],
                 ],


### PR DESCRIPTION
Hey @bakura10!

When trying to make a request loadnig additional relations, I got this error:
>Validation errors: [load_relations] must be of type array

So this PR changes the descriptors to make "load_relations" a string (since `json_encode` transforns the array in string).

But unfortunately this does not fix my problem at all. Now I'm getting a 400 response because Guzzle is serializing the load_relations value like that: `load_relations=%22%5B%5C%22Contact%5C%22%5D%22`.
And Lighstpeed Retail API expects `load_relations=["Contact"]`. How can I tell Guzzle to serialize the value without encoding it?