### PR TITLE
Allow additional query params

### DIFF
--- a/src/OAuth/AuthorizationMiddleware.php
+++ b/src/OAuth/AuthorizationMiddleware.php
@@ -155,6 +155,9 @@ final class AuthorizationMiddleware
             'headers' => ['Authorization' => 'Bearer ' . $credential->getAccessToken()],
         ];
 
+        // Remove internal referenceID param from command
+        unset($command['referenceID']);
+
         return $command;
     }
 

--- a/src/ServiceDescription/Lightspeed-Retail-2016.25.php
+++ b/src/ServiceDescription/Lightspeed-Retail-2016.25.php
@@ -74,7 +74,7 @@ return [
                     'required' => false,
                 ],
             ],
-            'additionalProperties' => [
+            'additionalParameters' => [
                 'location' => 'query',
             ],
         ],
@@ -208,7 +208,7 @@ return [
                     'required' => false,
                 ],
             ],
-            'additionalProperties' => [
+            'additionalParameters' => [
                 'location' => 'query',
             ],
         ],
@@ -337,7 +337,7 @@ return [
                     'required' => false,
                 ],
             ],
-            'additionalProperties' => [
+            'additionalParameters' => [
                 'location' => 'query',
             ],
         ],

--- a/test/OAuth/AuthorizationMiddlewareTest.php
+++ b/test/OAuth/AuthorizationMiddlewareTest.php
@@ -63,9 +63,11 @@ final class AuthorizationMiddlewareTest extends TestCase
 
         $httpClient->request(Argument::any())->shouldNotBeCalled();
 
-        $result = $middleware(new Command('Test', ['referenceID' => $referenceId]))->wait();
+        $command = new Command('Test', ['referenceID' => $referenceId]);
+        $result  = $middleware($command)->wait();
 
         $this->assertSame('success', $result['message']);
+        $this->assertArrayNotHasKey('referenceID', $command);
     }
 
     public function testForwardsNon401Errors()


### PR DESCRIPTION
* Fixes the description key `additionalProperties` -> `additionalParameters`
* Removes `referenceID` param from command before it reaches the HTTP handler.