### PR TITLE
Avoid throttling

### DIFF
--- a/src/LeakyBucketMiddleware.php
+++ b/src/LeakyBucketMiddleware.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrLightspeedRetail;
+
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @author Daniel Gimenes
+ */
+final class LeakyBucketMiddleware
+{
+    private const REQUIRED_UNITS = [
+        'GET'    => 1,
+        'POST'   => 10,
+        'PUT'    => 10,
+        'DELETE' => 10,
+    ];
+
+    /**
+     * @var callable
+     */
+    private $nextHandler;
+
+    /**
+     * @var null|ResponseInterface
+     */
+    private $lastResponse;
+
+    /**
+     * @param callable $nextHandler
+     */
+    public function __construct(callable $nextHandler)
+    {
+        $this->nextHandler = $nextHandler;
+    }
+
+    /**
+     * Creates a callable that wraps the middleware with the next handler of HandlerStack
+     *
+     * @see HandlerStack
+     *
+     * @return callable
+     */
+    public static function wrapped(): callable
+    {
+        return function (callable $nextHandler): self {
+            return new self($nextHandler);
+        };
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @param array            $options
+     *
+     * @return PromiseInterface
+     */
+    public function __invoke(RequestInterface $request, array $options): PromiseInterface
+    {
+        if (null === $this->lastResponse || ! $this->lastResponse->hasHeader('X-LS-API-Bucket-Level')) {
+            return $this->execute($request, $options);
+        }
+
+        $headerParts    = explode('/', $this->lastResponse->getHeaderLine('X-LS-API-Bucket-Level'));
+        $usedUnits      = (float) $headerParts[0];
+        $bucketSize     = (int) $headerParts[1];
+        $availableUnits = $bucketSize - $usedUnits;
+        $requiredUnits  = self::REQUIRED_UNITS[strtoupper($request->getMethod())];
+
+        if ($requiredUnits <= $availableUnits) {
+            return $this->execute($request, $options);
+        }
+
+        $dripRate    = $bucketSize / 60;
+        $unitsToWait = $requiredUnits - $availableUnits;
+
+        // Time to wait (in ms) until we have enough units to execute this request without throttling
+        $options['delay'] = (int) ceil($unitsToWait / $dripRate * 1000);
+
+        return $this->execute($request, $options);
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @param array            $options
+     *
+     * @return PromiseInterface
+     */
+    private function execute(RequestInterface $request, array $options): PromiseInterface
+    {
+        // Execute request and store the response for later usage
+        return ($this->nextHandler)($request, $options)->then(function (ResponseInterface $response) {
+            $this->lastResponse = $response;
+
+            return $response;
+        });
+    }
+}

--- a/src/RetryStrategy.php
+++ b/src/RetryStrategy.php
@@ -54,7 +54,7 @@ class RetryStrategy
      *
      * @return bool
      */
-    public function decide(
+    public function __invoke(
         int $retries,
         RequestInterface $request,
         ResponseInterface $response = null,
@@ -76,34 +76,5 @@ class RetryStrategy
         }
 
         return false;
-    }
-
-    /**
-     * @param int                    $retries
-     * @param ResponseInterface|null $response
-     *
-     * @return int
-     */
-    public function delay(int $retries, ResponseInterface $response = null): int
-    {
-        if (null === $response || ! $response->hasHeader('X-LS-API-Bucket-Level')) {
-            return 0;
-        }
-
-        $header     = $response->getHeaderLine('X-LS-API-Bucket-Level');
-        $parts      = explode('/', $header);
-        $usedUnits  = (int) reset($parts);
-        $bucketSize = (int) end($parts);
-
-        if (0 === $bucketSize) {
-            return 0;
-        }
-
-        $dripRate = $bucketSize / 60;
-
-        // We need 10 units for POST and PUT requests
-        $neededUnits = 10 - ($bucketSize - $usedUnits);
-
-        return $neededUnits / $dripRate * 1000;
     }
 }

--- a/test/LeakyBucketMiddlewareTest.php
+++ b/test/LeakyBucketMiddlewareTest.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrLightspeedRetailTest;
+
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Traversable;
+use ZfrLightspeedRetail\LeakyBucketMiddleware;
+
+/**
+ * @author Daniel Gimenes
+ */
+final class LeakyBucketMiddlewareTest extends TestCase
+{
+    public function testDoesNotDelayIfUnknownBucketLevel()
+    {
+        $nextHandler = function (RequestInterface $request, array $options): PromiseInterface {
+            $this->assertArrayNotHasKey('delay', $options);
+
+            $promise = new Promise();
+
+            $promise->resolve(new Response());
+
+            return $promise;
+        };
+
+        $request    = new Request('GET', 'http://localhost');
+        $middleware = new LeakyBucketMiddleware($nextHandler);
+
+        // Initial request should not be throttled because there's no last response
+        $response = $middleware($request, [])->wait();
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+
+        // Second request should not be throttled because the last response does not have bucket level header
+        $response = $middleware($request, [])->wait();
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @dataProvider provideRequests
+     *
+     * @param string   $requestMethod
+     * @param string   $bucketLevel
+     * @param null|int $expectedDelay
+     */
+    public function testAvoidsThrottling(
+        string $requestMethod,
+        string $bucketLevel,
+        int $expectedDelay = null
+    ) {
+        $request          = new Request($requestMethod, 'http://localhost');
+        $delayedTime      = null;
+        $expectedResponse = null;
+
+        $nextHandler = function (RequestInterface $request, array $options) use ($bucketLevel, &$delayedTime) {
+            $delayedTime = $options['delay'] ?? null;
+            $promise     = new Promise();
+
+            $promise->resolve(new Response(200, ['X-LS-API-Bucket-Level' => $bucketLevel]));
+
+            return $promise;
+        };
+
+        $middleware = new LeakyBucketMiddleware($nextHandler);
+
+        // Make initial request so that it stores the last response internally
+        $middleware($request, [])->wait();
+
+        // Make the second request, which should be delayed
+        $response = $middleware($request, [])->wait();
+
+        $this->assertSame($expectedDelay, $delayedTime);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @return Traversable
+     */
+    public function provideRequests(): Traversable
+    {
+        yield ['GET',  '59/60', null];
+        yield ['POST', '50/60', null];
+        yield ['GET',  '60/60', 1000];
+        yield ['GET',  '61/60', 2000];
+        yield ['POST', '55/60', 5000];
+    }
+}

--- a/test/RetryStrategyTest.php
+++ b/test/RetryStrategyTest.php
@@ -52,7 +52,7 @@ final class RetryStrategyTest extends TestCase
     ) {
         $this->assertSame(
             $shouldRetry,
-            (new RetryStrategy(10))->decide($retries, $request, $response, $exception)
+            (new RetryStrategy(10))($retries, $request, $response, $exception)
         );
     }
 
@@ -76,33 +76,5 @@ final class RetryStrategyTest extends TestCase
 
         // Other exception
         yield [false, 1, $request, null, new ClientException('Boom!', $request)];
-    }
-
-    public function testZeroDelayIfNoResponse()
-    {
-        $this->assertSame(0, (new RetryStrategy(10))->delay(1));
-    }
-
-    public function testZeroDelayIfResponseWithoutHeader()
-    {
-        $this->assertSame(0, (new RetryStrategy(10))->delay(1, new Response()));
-    }
-
-    public function testZeroDelayIfCantDetermineTheBucketSize()
-    {
-        $this->assertSame(0, (new RetryStrategy(10))->delay(
-            1,
-            (new Response())->withHeader('X-LS-API-Bucket-Level', 'Invalid')
-        ));
-    }
-
-    public function testCalculatesDelayBasedOnResponseHeader()
-    {
-        // We used 55 of 60, and we need 10, so we should wait for 5 more units.
-        // Since the drip rate is 1 unit per second, we should wait 5 seconds
-        $this->assertSame(5000, (new RetryStrategy(10))->delay(
-            1,
-            (new Response())->withHeader('X-LS-API-Bucket-Level', '55/60')
-        ));
     }
 }


### PR DESCRIPTION
As explained in http://developers.lightspeedhq.com/retail/introduction/ratelimits/, this `LeakyBucketMiddleware` avoids throttling by delaying requests until we have enough space in our bucket to execute the request.